### PR TITLE
fix: 修复Vue模板编译错误

### DIFF
--- a/index-zh.html
+++ b/index-zh.html
@@ -245,13 +245,10 @@
                 </div> -->
                 <!-- 根据需要切换中英文作为首页 -->
                 <div class="language switch-language">
-                    <a href="index.html" class="en" draggable="false" onclick='saveLanguage("en")'>En</a>
+                    <a href="index.html" class="en" draggable="false" @click="saveLanguage('en')">En</a>
                     <span>/</span>
                     <a href="javascript:;" target="_self" class="zh active" draggable="false">中</a>
                 </div>
-                <script>
-                    const saveLanguage = (lang) => localStorage.setItem('uiineed-todos-lang', 'en');
-                </script>
             </div>
 
         </div>
@@ -491,6 +488,9 @@
                 },
                 afterEnter(dom) {
                     dom.classList.remove('drag-enter-to');
+                },
+                saveLanguage(lang) {
+                    localStorage.setItem('uiineed-todos-lang', lang);
                 }
             },
             mounted() {

--- a/index.html
+++ b/index.html
@@ -362,11 +362,8 @@
                     <div class="language switch-language">
                         <a href="javascript:void(0)" class="en active" draggable="false">En</a>
                         <span>/</span>
-                        <a href="index-zh.html" target="_self" class="zh" draggable="false" onclick='saveLanguage("zh")'>中</a>
+                        <a href="index-zh.html" target="_self" class="zh" draggable="false" @click="saveLanguage('zh')">中</a>
                     </div>
-                    <script>
-                        const saveLanguage = (lang) => localStorage.setItem('uiineed-todos-lang', 'zh');
-                    </script>
                 </div>
 
             </div>
@@ -598,6 +595,9 @@
                     },
                     afterEnter(dom) {
                         dom.classList.remove('drag-enter-to');
+                    },
+                    saveLanguage(lang) {
+                        localStorage.setItem('uiineed-todos-lang', lang);
                     }
                 },
 


### PR DESCRIPTION
移除了模板中的<script>标签，将saveLanguage函数移动到app的methods里，使其符合Vue.js框架的语法规范。